### PR TITLE
fix: README badge formatting — add missing newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Cos72
 
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)All contract are here： https://github.com/jhfnetboy/Cos72-contracts/tree/dev
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+All contract are here： https://github.com/jhfnetboy/Cos72-contracts/tree/dev
 ## Introduction
 
 Yet Another DAO/Community Tool, BUT: get a Gasless,NFT,Contract Account, and ENS, with your Email on any Super Chain. 


### PR DESCRIPTION
Fix badge and text concatenated on same line. Adds blank line after license badge.